### PR TITLE
WIP: Add pagination

### DIFF
--- a/src/amber/cli/templates/app/src/views/layouts/_pagination.ecr
+++ b/src/amber/cli/templates/app/src/views/layouts/_pagination.ecr
@@ -1,0 +1,46 @@
+<nav aria-label="Pagination">
+    <ul class="pagination pagination-circle pg-blue">
+        <% unless page_number == 0 %>
+            <li class="page-item"><a href="?page_number=0" class="page-link">First</a></li>
+            <li class="page-item"><a href="?page_number=<%= page_number - 1 %>" class="page-link">
+                <span aria-hidden="true">&laquo;</span>
+                <span class="sr-only">Previous</span>
+            </a></li>
+        <% end %>
+
+        <% unless page_count > 10 %>
+        <% page_count.times do |i| %>
+            <%
+            if i == page_number
+              active = "active"
+            else
+              active = ""
+            end
+            %>
+            <li class="page-item <%= active %>"><a href="?page_number=<%= i %>" class="page-link"><%= i %></a></li>
+        <% end %>
+        <% else %>
+            <% n = page_number - 5 %>
+             <% 10.times do |i| %>
+                <%
+                if (n + i) == page_number
+                    active = "active"
+                else
+                    active = ""
+                end
+                %>
+                <% if ((i + n) <= (page_count - 1)) && (i + n) >= 0 %>
+                    <li class="page-item <%= active %>"><a href="?page_number=<%= (n + i) %>" class="page-link"><%= (n + i) %></a></li>
+                <% end %>
+            <% end %>
+        <% end %>
+
+        <% unless page_number == (page_count - 1)  %>
+        <li class="page-item"><a href="?page_number=<%= page_number + 1 %>" class="page-link">
+            <span aria-hidden="true">&raquo;</span>
+            <span class="sr-only">Next</span>
+        </a></li>
+        <li class="page-item"><a href="?page_number=<%= page_count -1 %>" class="page-link">Last</a></li>
+        <% end %>
+    </ul>
+</nav>


### PR DESCRIPTION
This pull request adds a partial for pagination. It requires the user to use the `?page_number=` query string and it requires that they include a `page_count` variable in their controller before loading the view. Unlike the other layouts, the user will need to include `<%= render(partial: "layouts/_pagination.ecr") %>` into the appropriate template on their own. From there they are responsible for modifying their Granite/ORM queries to limit the rows returned and to skip rows based on the limit and page number.

I did as follows in my controller and it works out well.
```ruby
page_number = params[:page_number]?.try &.to_i64 || 0
offset = page_number * 10
count = Model.where(CONDITION).count.run
page_count = (count.as(Int64) / 10).ceil.to_i64
```

The resulting output is:
![image](https://user-images.githubusercontent.com/8227641/70868234-b4d42900-1f4c-11ea-84af-7bc092ed1e55.png)
![image](https://user-images.githubusercontent.com/8227641/70868250-ccabad00-1f4c-11ea-9d87-b782f1d6eb3b.png)
![image](https://user-images.githubusercontent.com/8227641/70868246-c4ec0880-1f4c-11ea-9da9-ff030ea71f75.png)

To-do:

- [ ] Slang templates
- [ ] Unit tests
- [ ] Update documentation